### PR TITLE
Update Wizard College

### DIFF
--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -677,6 +677,18 @@ const Koviko = {
           tick: (p, a, s, k) => offset => (g.getSkillLevelFromExp(k.magic) / 2 + g.getSkillLevelFromExp(k.crafting)) * (1 + g.getLevelFromExp(s[a.loopStats[(p.completed + offset) % a.loopStats.length]]) / 100) * Math.sqrt(1 + p.total / 1000),
           effect: { segment: (r, k) => (r.gold += 10, r.crafts++, k.crafting += 50) }
         }},
+        'Wizard College': { affected: ['gold', 'favors', 'wizrank'],
+          canStart: (input) => (input.gold >= 500, input.favors >=10),
+          effect: (input) => (input.gold -=500, input.favors -=10),
+          loop: {
+            cost: (p) => segment => g.precision3(Math.pow(1.2, p.completed + segment)) * 5e6,
+            tick: (p, a, s, k) => offset => (
+	      (g.getSkillLevelFromExp(k.magic) + g.getSkillLevelFromExp(k.practical) + g.getSkillLevelFromExp(k.dark) + g.getSkillLevelFromExp(k.chronomancy) + 
+	        g.getSkillLevelFromExp(k.pyromancy) + g.getSkillLevelFromExp(k.restoration) + g.getSkillLevelFromExp(k.spatiomancy)) * 
+	      (1 + g.getLevelFromExp(s[a.loopStats[(p.completed + offset) % a.loopStats.length]]) / 100) * Math.sqrt(1 + p.total / 1000)
+	    ),
+          effect: { segment: (r) => (r.wizrank++) }
+        }},
         'Hunt Trolls': { affected: ['blood'], loop: {
           cost: (p, a) => segment => g.precision3(Math.pow(2, Math.floor((p.completed + segment) / a.segments+.0000001)) * 1e6),
           tick: (p, a, s, k, r) => offset => (h.getSelfCombat(r, k) * Math.sqrt(1 + p.total/100) * (1 + g.getLevelFromExp(s[a.loopStats[(p.completed + offset) % a.loopStats.length]])/100)),
@@ -729,14 +741,6 @@ const Koviko = {
           },
           effect: { loop: (r) => r.mind++ },
         }},
-      'Wizard College': { affected: ['gold', 'favors', 'wizrank'],
-          canStart: (input) => (input.gold >= 500, input.favors >=10),
-          effect: (input) => (input.gold -=500, input.favors -=10),
-          loop: {
-            cost: (p) => segment => g.precision3(Math.pow(1.2, p.completed + segment)) * 5e6,
-            tick: (p, a, s, k) => offset =>  getSkillLevel("Magic") + getSkillLevel("Practical") + getSkillLevel("Dark") + getSkillLevel("Chronomancy") + getSkillLevel("Pyromancy") + getSkillLevel("Chronomancy") + getSkillLevel("Restoration") + getSkillLevel("Spatiomancy")  * (1 + g.getLevelFromExp(s[a.loopStats[(p.completed + offset) % a.loopStats.length]]) / 100) * Math.sqrt(1 + p.total / 1000),
-          effect: { segment: (r) => (r.wizrank++) }
-       }},
       };
 
       /**

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -691,7 +691,7 @@ const Koviko = {
 	      segment: (r) => (r.wizrank++),
 	      end: (r, k, ps) => (
 	        ps['Restoration'].action.manaCost = () => 30000 / precision3(1 + r.wizrank / 20 + Math.pow(r.wizrank, 2) / 300),
-		ps['Restoration'].action.manaCost = () => 30000 / precision3(1 + r.wizrank / 20 + Math.pow(r.wizrank, 2) / 300)
+		ps['Spatiomancy'].action.manaCost = () => 30000 / precision3(1 + r.wizrank / 20 + Math.pow(r.wizrank, 2) / 300)
 	      )
             }
           }

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -687,8 +687,15 @@ const Koviko = {
 	        g.getSkillLevelFromExp(k.pyromancy) + g.getSkillLevelFromExp(k.restoration) + g.getSkillLevelFromExp(k.spatiomancy)) * 
 	      (1 + g.getLevelFromExp(s[a.loopStats[(p.completed + offset) % a.loopStats.length]]) / 100) * Math.sqrt(1 + p.total / 1000)
 	    ),
-          effect: { segment: (r) => (r.wizrank++) }
-        }},
+            effect: { 
+	      segment: (r) => (r.wizrank++),
+	      end: (r, k, ps) => (
+	        ps['Restoration'].action.manaCost = () => 30000 / precision3(1 + r.wizrank / 20 + Math.pow(r.wizrank, 2) / 300),
+		ps['Restoration'].action.manaCost = () => 30000 / precision3(1 + r.wizrank / 20 + Math.pow(r.wizrank, 2) / 300)
+	      )
+            }
+          }
+	},
         'Hunt Trolls': { affected: ['blood'], loop: {
           cost: (p, a) => segment => g.precision3(Math.pow(2, Math.floor((p.completed + segment) / a.segments+.0000001)) * 1e6),
           tick: (p, a, s, k, r) => offset => (h.getSelfCombat(r, k) * Math.sqrt(1 + p.total/100) * (1 + g.getLevelFromExp(s[a.loopStats[(p.completed + offset) % a.loopStats.length]])/100)),
@@ -873,8 +880,6 @@ const Koviko = {
             // Calculate the total amount of mana used in the prediction and add it to the total
             total += currentMana - state.resources.mana;
 
-
-
             // Calculate time spent
             let temp = (currentMana - state.resources.mana) / Math.pow(1 + getSkillLevel("Chronomancy") / 60, 0.25);
             if ( state.resources.town === 0 && getBuffLevel("Ritual") > 0) {
@@ -899,7 +904,7 @@ const Koviko = {
             }
             if (prediction.loop) {
               if (prediction.loop.effect.end) {
-                prediction.loop.effect.end(state.resources, state.skills);
+                prediction.loop.effect.end(state.resources, state.skills, this.predictions);
               }
             }
           }


### PR DESCRIPTION
Wizard college levels were not being correctly calculated by the predictor.  This patch fixes it so that Wizard College is calculated and displayed per segment like Adventure and Crafting Guild.